### PR TITLE
Fix: commands that require a thingName

### DIFF
--- a/commands/noThing.js
+++ b/commands/noThing.js
@@ -1,0 +1,10 @@
+// Require functions
+const reply = require("../functions/reply");
+
+module.exports = {
+    name: 'noThing',
+    description: "Replies that command does not include a thing",
+    execute(message){
+        reply.noThing(message);
+    }
+}

--- a/functions/reply.js
+++ b/functions/reply.js
@@ -147,5 +147,15 @@ replyObj.unknownCommand = function(message) {
     }).catch(console.error);
 };
 
+// ERROR: NO THING GIVEN
+replyObj.noThing = function(message) {
+    message.reply({
+        embed: {
+          color: "RED",
+          description: `Command did not include a thing!`
+        }
+    }).catch(console.error);
+};
+
 //  Export reply object
 module.exports = replyObj;


### PR DESCRIPTION
# Fix

For issue #7 

Commands that require a thingName now produce an error and do not crash the bot.

The command tree has been split into 2 branches:
- one for commands that require a thingName if thingName is true.
- one for if there is no thingName for commands that do not require it.

If no commands that do not require a thingName are triggered either the thingName was omitted from one that does and the new error is triggered, or it was a getThing command and is then executed.