### PR TITLE
Feature Update 4.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,11 @@ Commands are formated and limited in scope such that users interact with the poi
 - **`sk adminset <thing> <value>`**: Sets a \<thing\>'s karma to the value
 - **`sk admindelete <thing>`**: Deletes a \<thing\>
 
-*Note: Prefix and commands are case insensitive.*
-*Note: Thing names in parentheses can have spaces.*
+**Notes:**
+- *Prefix and commands are case insensitive.*
+- *Thing names in parentheses can have spaces.*
+- *User Thing names with spaces must have a space between the @ and the rest of the name.*
+  - *Example: `(@ Joe User)` for `@Joe User`*
 
 ## Current Scope
 - Help documentation

--- a/app.js
+++ b/app.js
@@ -63,13 +63,22 @@ client.on('message', message => {
   if (getThingName && getThingName.startsWith('@') && getThingName.charCodeAt(1) === 8203) {
     getThingName = getThingName.slice(0, 1) + getThingName.slice(2)
   }
+
   // remove parens from thingName if present for things that include spaces
   if (thingName && thingName.startsWith('(') && thingName.endsWith(')')) {
     thingName = thingName.slice(1, -1)
   }
+  // remove space from thingName after @ for user names with spaces
+  if (thingName && thingName.startsWith('@') && thingName.charCodeAt(1) === 32) {
+    thingName = thingName.slice(0, 1) + thingName.slice(2)
+  }
   // remove parens from getThingName if present for things that include spaces
   if (getThingName && getThingName.startsWith('(') && getThingName.endsWith(')')) {
     getThingName = getThingName.slice(1, -1)
+  }
+  // remove space from getThingName after @ for user names with spaces
+  if (getThingName && getThingName.startsWith('@') && getThingName.charCodeAt(1) === 32) {
+    getThingName = getThingName.slice(0, 1) + getThingName.slice(2)
   }
 
   if (value) {

--- a/commands/help.js
+++ b/commands/help.js
@@ -16,8 +16,11 @@ module.exports = {
       '**`sk + <thing>`**: Increments a thing\'s karma',
       '**`sk - <thing>`**: Decrements a thing\'s karma',
       '**`sk delete <thing>`**: Deletes a thing. Only bad people do this.',
-      '*Note: Prefix and commands are case insensitive.*',
-      '*Note: Thing names in parentheses can have spaces.*'
+      'Notes:',
+      '*- Prefix and commands are case insensitive.*',
+      '*- Thing names in parentheses can have spaces.*',
+      '*- User Thing names with spaces must have a space between the @ and the rest of the name.*',
+      '*  - Example: `(@ Joe User)` for `@Joe User`*'
     ])
     if (message.member.hasPermission('ADMINISTRATOR')) {
       message.author.send([


### PR DESCRIPTION
# Feature Update 4.5

- User Thing names with spaces: User Thing names can now have spaces in them if surrounded by parentheses and a space is added between the @ and the rest of the name.
  - *Example: `(@ Joe User)` for `@Joe User`*

## Changes
- Update README with new commands note and scope.
- Update Help command with new note.
- Reformat the notes in help and readme.