### PR TITLE
Fix: remove parens for values with spaces and space for values with @

### DIFF
--- a/app.js
+++ b/app.js
@@ -64,7 +64,7 @@ client.on('message', message => {
   let command = argsArray[0]
   let thingName = argsArray[1]
   let getThingName = argsArray[0]
-  const value = argsArray[2]
+  let value = argsArray[2]
 
   // args transformations
   if (command) {
@@ -93,6 +93,15 @@ client.on('message', message => {
   // remove space from getThingName after @ for user names with spaces
   if (getThingName && getThingName.startsWith('@') && getThingName.charCodeAt(1) === 32) {
     getThingName = getThingName.slice(0, 1) + getThingName.slice(2)
+  }
+
+  // remove parens from value if present for things that include spaces
+  if (value && value.startsWith('(') && value.endsWith(')')) {
+    value = value.slice(1, -1)
+  }
+  // remove space from value after @ for user names with spaces
+  if (value && value.startsWith('@') && value.charCodeAt(1) === 32) {
+    value = value.slice(0, 1) + value.slice(2)
   }
 
   // DEBUG


### PR DESCRIPTION
# Fix: remove parens for values with spaces and space for values with @

Previously, for the adminRename command you may want to include spaces or a @ in the new name and this string would be stored in the value variable. There was no processing done on value to remove the parens required to use spaces or @s. That has been fixed in the same way it was for variables thingName and getThingName.