### PR TITLE
Fixes: namePoints docs and admin permission, next undo reply

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,22 +9,23 @@ Commands are formatted and limited in scope such that users interact with the po
 
 ## Commands
 - Syntax: \<prefix\> \<command\> \<thing\>(optional)
-- **`sk help`**: DMs this list to you
-- **`sk new <thing>`**: Creates a new \<thing\>
+- **`sk help`**: DMs this list to you.
+- **`sk new <thing>`**: Creates a new \<thing\>.
 - **`sk search <string>`**: DMs a list of \<thing\>s with names that include the given string. Searching `*` returns all.
 - **`sk best`**: Shows a list of the best five things by points.
 - **`sk worst`**: Shows a list of the worst five things by points.
-- **`sk <thing>`**: Shows a \<thing\>'s points
-- **`sk + <thing>`**: Increments a \<thing\>'s points, if it doesn't exist it is created
-- **`sk - <thing>`**: Decrements a \<thing\>'s points, if it doesn't exist it is created
+- **`sk <thing>`**: Shows a \<thing\>'s points.
+- **`sk + <thing>`**: Increments a \<thing\>'s points, if it doesn't exist it is created.
+- **`sk - <thing>`**: Decrements a \<thing\>'s points, if it doesn't exist it is created.
 - **`sk delete <thing>`**: Deletes a \<thing\>. Only bad people do this.
 
 **Admin Commands**
 - Syntax: \<prefix\> \<command\> \<thing\>(optional)
-- **`sk adminset <thing> <value>`**: Sets a \<thing\>'s points to the \<value\>
-- **`sk adminrename <thing> <value>`**: Renames a \<thing\> to the \<value\>
-- **`sk admindelete <thing>`**: Deletes a \<thing\>
-- **`sk undo`**: Undoes the last command that changed a thing
+- **`sk adminset <thing> <value>`**: Sets a \<thing\>'s points to the \<value\>.
+- **`sk adminrename <thing> <value>`**: Renames a \<thing\> to the \<value\>.
+- **`sk admindelete <thing>`**: Deletes a \<thing\>.
+- **`sk undo`**: Undoes the last command that changed a thing.
+- **`sk namepoints <name>`**: Sets the name for points to \<name\>.
 
 **Notes:**
 - *Prefix, commands, and thing names are case insensitive.*
@@ -54,6 +55,7 @@ Commands are formatted and limited in scope such that users interact with the po
 - Thing names in parentheses can have spaces. Example: `(SimpleKarma Discord Bot)` and `(@ SimpleKarma Bot)`
 - Get debug info DM'd to you
 - Undo changes
+- Rename the points for your server
 
 ## Future Scope
 

--- a/commands/help.js
+++ b/commands/help.js
@@ -34,7 +34,8 @@ module.exports = {
         '**`sk adminset <thing> <value>`**: Sets a thing\'s points to the value',
         '**`sk adminrename <thing> <value>`**: Renames a thing to the value',
         '**`sk admindelete <thing>`**: Deletes a thing',
-        '**`sk undo`**: Undoes the last command that changed a thing'
+        '**`sk undo`**: Undoes the last command that changed a thing',
+        '**`sk namepoints <name>`**: Sets the name for points to the name.'
       ])
     }
 

--- a/commands/namePoints.js
+++ b/commands/namePoints.js
@@ -5,26 +5,31 @@ module.exports = {
   name: 'namePoints',
   description: 'Sets the name of the points for a server object',
   async execute (message, pointsName, debugLog, debugFlag) {
-    // check if the database already has the server
-    const [foundServer, debugDB] = await db.findServer(message.guild.id)
+    if (message.member.hasPermission('ADMINISTRATOR')) {
+      // check if the database already has the server
+      const [foundServer, debugDB] = await db.findServer(message.guild.id)
 
-    // debug
-    const debug = `  DEBUG: 2. namePoints.js, foundServer: ${foundServer}`
-    console.log(debug)
+      // debug
+      const debug = `  DEBUG: 2. namePoints.js, foundServer: ${foundServer}`
+      console.log(debug)
 
-    // if it does, change the name of the points then send reply confirming the change
-    if (foundServer) {
-      foundServer.pointsName = pointsName
-      foundServer.save()
-      reply.pointsNameSet(message, pointsName)
-      // if it doesn't, create the server then send reply to the message's channel confirming it's creation
-    } else {
-      const newThing = await db.createServer(message.guild.id, pointsName)
-      if (newThing) {
+      // if it does, change the name of the points then send reply confirming the change
+      if (foundServer) {
+        foundServer.pointsName = pointsName
+        foundServer.save()
         reply.pointsNameSet(message, pointsName)
+        // if it doesn't, create the server then send reply to the message's channel confirming it's creation
       } else {
-        reply.serverNotCreated(message)
+        const newThing = await db.createServer(message.guild.id, pointsName)
+        if (newThing) {
+          reply.pointsNameSet(message, pointsName)
+        } else {
+          reply.serverNotCreated(message)
+        }
       }
+      // if message author does not have permission, send error reply
+    } else {
+      reply.noPermission(message)
     }
 
     // if debugFlag, DM debug

--- a/commands/namePoints.js
+++ b/commands/namePoints.js
@@ -5,12 +5,17 @@ module.exports = {
   name: 'namePoints',
   description: 'Sets the name of the points for a server object',
   async execute (message, pointsName, debugLog, debugFlag) {
+    // create debugDB variable to handle DM'ing in different cases and debug variable for wider scope
+    let debugDB = ''
+    let debug = ''
+
     if (message.member.hasPermission('ADMINISTRATOR')) {
       // check if the database already has the server
-      const [foundServer, debugDB] = await db.findServer(message.guild.id)
+      const [foundServer, debugDBThing] = await db.findServer(message.guild.id)
+      debugDB += debugDBThing
 
       // debug
-      const debug = `  DEBUG: 2. namePoints.js, foundServer: ${foundServer}`
+      debug += `  DEBUG: 2. namePoints.js, foundServer: ${foundServer}`
       console.log(debug)
 
       // if it does, change the name of the points then send reply confirming the change

--- a/commands/undo.js
+++ b/commands/undo.js
@@ -52,7 +52,11 @@ module.exports = {
               console.log('  DEBUG: undo.js: reached default case')
               reply.noUndoCase(message)
           }
-          if (undos[message.guild.id].length) reply.nextUndo(message, undos[message.guild.id][undos[message.guild.id].length - 1])
+          if (undos[message.guild.id].length) {
+            reply.nextUndo(message, undos[message.guild.id][undos[message.guild.id].length - 1])
+          } else {
+            reply.noUndoNext(message)
+          }
         } else {
           reply.noUndoCase(message)
         }

--- a/functions/reply.js
+++ b/functions/reply.js
@@ -332,6 +332,16 @@ replyObj.noUndoCase = function (message) {
   }).catch(console.error)
 }
 
+// INFO: NO NEXTUNDO
+replyObj.noUndoNext = function (message) {
+  message.reply({
+    embed: {
+      color: 'GREY',
+      description: 'There are no more commands to undo.'
+    }
+  }).catch(console.error)
+}
+
 // INFO: NEXT UNDO
 replyObj.nextUndo = function (message, undo) {
   if (undo.command === 'untroll') {


### PR DESCRIPTION
# Fixes: namePoints docs and admin permission, next undo reply

- The namepoints command has been added to the README and help command.
- The namePoints command now requires admin permission.
- The undo command will now send an info reply saying there is nothing to undo next when there are no more undos in the undo array after the undo being carried out.