### PR TITLE
Change: Rename adminSet and admin Rename

### DIFF
--- a/app.js
+++ b/app.js
@@ -180,8 +180,8 @@ client.on('message', async message => {
         // admin commands
       } else if (command === 'set') {
         client.commands.get('set').execute(message, thingName, value, debugLog, debugFlag, false, true, pointsName)
-      } else if (command === 'adminrename') {
-        client.commands.get('adminRename').execute(message, thingName, value, debugLog, debugFlag, false, true, pointsName)
+      } else if (command === 'rename') {
+        client.commands.get('rename').execute(message, thingName, value, debugLog, debugFlag, false, true, pointsName)
       } else if (command === 'admindelete') {
         client.commands.get('adminDelete').execute(message, thingName, debugLog, debugFlag, false, true)
       } else if (command === 'namepoints') {

--- a/app.js
+++ b/app.js
@@ -178,8 +178,8 @@ client.on('message', async message => {
       } else if (command === 'delete') {
         client.commands.get('trollDelete').execute(message, thingName, debugLog, debugFlag, pointsName)
         // admin commands
-      } else if (command === 'adminset') {
-        client.commands.get('adminSet').execute(message, thingName, value, debugLog, debugFlag, false, true, pointsName)
+      } else if (command === 'set') {
+        client.commands.get('set').execute(message, thingName, value, debugLog, debugFlag, false, true, pointsName)
       } else if (command === 'adminrename') {
         client.commands.get('adminRename').execute(message, thingName, value, debugLog, debugFlag, false, true, pointsName)
       } else if (command === 'admindelete') {

--- a/commands/rename.js
+++ b/commands/rename.js
@@ -3,7 +3,7 @@ const reply = require('../functions/reply')
 const undo = require('./undo')
 
 module.exports = {
-  name: 'adminRename',
+  name: 'rename',
   description: 'Renames a thing',
   async execute (message, thingName, value, debugLog, debugFlag, undoFlag, addUndoFlag, pointsName) {
     // create debugDB variable to handle DM'ing in different cases and debug variable for wider scope
@@ -17,7 +17,7 @@ module.exports = {
       debugDB += debugDBThing
 
       // debug
-      debug += `  DEBUG: 2. adminRename.js, foundThing: ${foundThing}`
+      debug += `  DEBUG: 2. rename.js, foundThing: ${foundThing}`
       console.log(debug)
 
       // if it doesn't, send reply to message's channel with error and instructions for how to create the thing

--- a/commands/set.js
+++ b/commands/set.js
@@ -4,7 +4,7 @@ const reply = require('../functions/reply')
 const undo = require('./undo')
 
 module.exports = {
-  name: 'adminSet',
+  name: 'set',
   description: 'Sets karma for a thing to a given value',
   async execute (message, thingName, value, debugLog, debugFlag, undoFlag, addUndoFlag, pointsName) {
     // create debugDB variable to handle DM'ing in different cases and debug variable for wider scope
@@ -21,7 +21,7 @@ module.exports = {
         debugDB += debugDBThing
 
         // debug
-        debug += `  DEBUG: 2. adminSet.js, foundThing: ${foundThing}`
+        debug += `  DEBUG: 2. set.js, foundThing: ${foundThing}`
         console.log(debug)
 
         // if it doesn't, send reply to message's channel with error and instructions for how to create the thing


### PR DESCRIPTION
# Change: Rename adminSet and admin Rename

- adminSet command has been renamed to simply 'set' and can be used with `sk set <thing> <value>`.
- adminRename command has been renamed to simply 'rename' and can be used with `sk rename <thing> <value>`.

Both commands still require admin permissions, they just don't make you type out the word 'admin' for no reason.