### PR TITLE
Fixes: Search command regex filtering, debug info, reply

### DIFF
--- a/app.js
+++ b/app.js
@@ -82,6 +82,11 @@ client.on('message', async message => {
   let value = argsArray[2]
 
   // args transformations
+  if (getThingName === 'search )') {
+    command = 'search'
+    thingName = ')'
+    getThingName = 'search'
+  }
   if (command) {
     command = command.toLowerCase()
   }

--- a/commands/searchThings.js
+++ b/commands/searchThings.js
@@ -8,7 +8,7 @@ module.exports = {
   async execute (message, char, debugLog, debugFlag, pointsName) {
     // filter for regex special chars
     if (char.includes('-')) {
-      char = '\-'
+      char = '\\-'
     } else if (char.includes('.')) {
       char = '\\.'
     } else if (char.includes('+')) {

--- a/commands/searchThings.js
+++ b/commands/searchThings.js
@@ -6,9 +6,31 @@ module.exports = {
   name: 'searchThings',
   description: 'DMs list of things with names containing a string',
   async execute (message, char, debugLog, debugFlag, pointsName) {
-    // if char is '*', return all
-    if (char === '*') {
+    // filter for regex special chars
+    if (char.includes('*')) {
       char = ''
+    } else if (char.includes('-')) {
+      char = '\-'
+    } else if (char.includes('.')) {
+      char = '\\.'
+    } else if (char.includes('+')) {
+      char = '\\+'
+    } else if (char.includes('?')) {
+      char = '\\?'
+    } else if (char.includes('$')) {
+      char = '\\$'
+    } else if (char.includes('{')) {
+      char = '\\{'
+    } else if (char.includes('}')) {
+      char = '\\}'
+    } else if (char.includes('(')) {
+      char = '\\('
+    } else if (char.includes(')')) {
+      char = '\\)'
+    } else if (char.includes('^')) {
+      char = '\\^'
+    } else if (char.includes('|')) {
+      char = '\\|'
     }
 
     // Search the database for things with names containing with the character

--- a/commands/searchThings.js
+++ b/commands/searchThings.js
@@ -7,9 +7,7 @@ module.exports = {
   description: 'DMs list of things with names containing a string',
   async execute (message, char, debugLog, debugFlag, pointsName) {
     // filter for regex special chars
-    if (char.includes('*')) {
-      char = ''
-    } else if (char.includes('-')) {
+    if (char.includes('-')) {
       char = '\-'
     } else if (char.includes('.')) {
       char = '\\.'
@@ -31,6 +29,8 @@ module.exports = {
       char = '\\^'
     } else if (char.includes('|')) {
       char = '\\|'
+    } else if (char.includes('*')) {
+      char = ''
     }
 
     // Search the database for things with names containing with the character

--- a/commands/searchThings.js
+++ b/commands/searchThings.js
@@ -37,7 +37,7 @@ module.exports = {
     const [foundThings, debugDB] = await db.find(message.guild.id, char)
 
     // debug
-    const debug = `  DEBUG: 2. searchThings.js, foundThing: ${foundThings}`
+    let debug = `  DEBUG: 2. searchThings.js, foundThing: ${foundThings.length}`
     console.log(debug)
 
     // if no things are found, send reply with error
@@ -45,7 +45,10 @@ module.exports = {
       reply.noThingsFound(message, char)
       // if things found, send DM to the message's author with things' karma
     } else {
-      reply.thingsFound(message, char, foundThings, pointsName)
+      const textLength = reply.thingsFound(message, char, foundThings, pointsName)
+      const debugReply = `  DEBUG: 3. searchThings.js, reply text.length: ${textLength}`
+      console.log(debugReply)
+      debug += debugReply
     }
 
     // if debugFlag, DM debug

--- a/functions/database.js
+++ b/functions/database.js
@@ -35,7 +35,7 @@ databaseObj.find = async function (server, char) {
   // debug
   const debugDB = `
   === find in Database ===
-  DEBUG: 1. database.js, foundThings: ${foundThings}`
+  DEBUG: 1. database.js, foundThings: ${foundThings.length}`
   console.log(debugDB)
 
   // if success, return the things

--- a/functions/database.js
+++ b/functions/database.js
@@ -28,9 +28,9 @@ databaseObj.findOne = async function (server, thingName) {
 
 // FIND THINGS
 databaseObj.find = async function (server, char) {
-  const regex = new RegExp(char, 'i')
+  const regex = new RegExp(char, 'g')
   // Search the database for things with names containing with the character
-  const foundThings = await Thing.find({ server: server, name: regex })
+  const foundThings = await Thing.find({ server: server, nameLower: regex })
 
   // debug
   const debugDB = `

--- a/functions/reply.js
+++ b/functions/reply.js
@@ -13,11 +13,10 @@ replyObj.found = function (message, foundThing, pointsName) {
 
 // SUCCESS: THINGS FOUND
 replyObj.thingsFound = function (message, char, foundThings, pointsName) {
+  let text = `.\nThings containing **${char}**:\n**Name**: ${pointsName}\n--------------------`
   if (char === '') {
-    char = '*'
+    text = `.\nAll things:\n**Name**: ${pointsName}\n--------------------`
   }
-
-  let text = `.\nThings containing **${char}**:\n\n**Name**: ${pointsName}\n--------------------`
   foundThings.forEach(thing => {
     text += `\n**${thing.name}**: ${thing.karma}`
   })

--- a/functions/reply.js
+++ b/functions/reply.js
@@ -34,6 +34,7 @@ replyObj.thingsFound = function (message, char, foundThings, pointsName) {
   } else {
     message.author.send([`${text}`]).catch(console.error)
   }
+  return text.length
 }
 
 // SUCCESS: BEST FOUND


### PR DESCRIPTION
# Fixes: Search command regex filtering, debug info, reply

Misc fixes and changes for the search command.

- Search now filters error-producing arguments that it will eventually pass to its database function.
- Searches that would produce debug DMs going over the 2000 char limit in Discord for messages will now be mitigated by reporting the number of results instead of the results themselves, saving on chars. Debug info will also include the text.length of the search results DM'd.
- The thingsFound reply for when variable char = '', when user gives argument `*`, will now say "All things" instead of the message, "Things that include" then the char given.