### PR TITLE
Fix: Undo creation debug info

### DIFF
--- a/commands/adminDelete.js
+++ b/commands/adminDelete.js
@@ -35,7 +35,11 @@ module.exports = {
 
         if (res === 1) {
           reply.thingDeleted(message, foundThing.name)
-          if (addUndoFlag) undo.execute(null, message, foundThing, 'create', null, null, null)
+          if (addUndoFlag) {
+            debugLog += '\n' + debugDB + '\n' + debug
+            undo.execute(null, message, foundThing, 'create', debugLog, debugFlag, null)
+            debugFlag = false
+          }
         } else {
           reply.thingNotDeleted(message, foundThing.name)
         }

--- a/commands/decrementKarma.js
+++ b/commands/decrementKarma.js
@@ -20,7 +20,11 @@ module.exports = {
       foundThing.karma -= 1
       foundThing.save()
       reply.found(message, foundThing, pointsName)
-      if (addUndoFlag) undo.execute(null, message, foundThing, 'increment', null, null, pointsName)
+      if (addUndoFlag) {
+        debugLog += '\n' + debugDB + '\n' + debug
+        undo.execute(null, message, foundThing, 'increment', debugLog, debugFlag, null)
+        debugFlag = false
+      }
       // if debugFlag, DM debug
       if (debugFlag) {
         message.author.send([

--- a/commands/incrementKarma.js
+++ b/commands/incrementKarma.js
@@ -24,7 +24,11 @@ module.exports = {
         foundThing.karma += 1
         foundThing.save()
         reply.found(message, foundThing, pointsName)
-        if (addUndoFlag) undo.execute(null, message, foundThing, 'decrement', null, null, pointsName)
+        if (addUndoFlag) {
+          debugLog += '\n' + debugDB + '\n' + debug
+          undo.execute(null, message, foundThing, 'decrement', debugLog, debugFlag, null)
+          debugFlag = false
+        }
         // if debugFlag, DM debug
         if (debugFlag) {
           message.author.send([

--- a/commands/newThing.js
+++ b/commands/newThing.js
@@ -26,7 +26,11 @@ module.exports = {
       const newThing = await db.create(message.guild.id, thingName, karma)
       if (newThing) {
         reply.thingCreated(message, newThing)
-        if (addUndoFlag) undo.execute(null, message, newThing, 'delete', null, null, null)
+        if (addUndoFlag) {
+          debugLog += '\n' + debugDB + '\n' + debug
+          undo.execute(null, message, newThing, 'delete', debugLog, debugFlag, null)
+          debugFlag = false
+        }
       } else {
         reply.thingNotCreated(message, thingName)
       }

--- a/commands/rename.js
+++ b/commands/rename.js
@@ -30,7 +30,11 @@ module.exports = {
         foundThing.save()
         reply.found(message, foundThing, pointsName)
         foundThing.value = thingName
-        if (addUndoFlag) undo.execute(null, message, foundThing, 'rename', null, null, pointsName)
+        if (addUndoFlag) {
+          debugLog += '\n' + debugDB + '\n' + debug
+          undo.execute(null, message, foundThing, 'rename', debugLog, debugFlag, null)
+          debugFlag = false
+        }
       }
       // if message author does not have permission, send error reply
     } else {

--- a/commands/set.js
+++ b/commands/set.js
@@ -34,7 +34,11 @@ module.exports = {
           foundThing.save()
           reply.found(message, foundThing, pointsName)
           foundThing.value = oldKarma
-          if (addUndoFlag) undo.execute(null, message, foundThing, 'set', null, null, pointsName)
+          if (addUndoFlag) {
+            debugLog += '\n' + debugDB + '\n' + debug
+            undo.execute(null, message, foundThing, 'set', debugLog, debugFlag, null)
+            debugFlag = false
+          }
         }
       } else {
         reply.notANumber(message, value)

--- a/commands/trollDelete.js
+++ b/commands/trollDelete.js
@@ -43,10 +43,12 @@ module.exports = {
           debug += `DEBUG: trollDelete.js, foundThing: ${foundThing}`
           console.log('DEBUG: trollDelete.js, foundThing: ' + foundThing)
 
-          // if it does, take the user's karma and give it to the thing
+          // if it does, create undo, reroute debug, take the user's karma and give it to the thing
           if (foundThing) {
             const undoStuff = { thingName: foundThing.name, thingKarma: foundThing.karma, userName: foundUser.name, userKarma: foundUser.karma }
-            undo.execute(null, message, undoStuff, 'untroll', null, null, null)
+            debugLog += '\n' + debugDB + '\n' + debug
+            undo.execute(null, message, undoStuff, 'untroll', debugLog, debugFlag, null)
+            debugFlag = false
             foundThing.karma += foundUser.karma
             foundThing.save()
             foundUser.karma = 0

--- a/commands/undo.js
+++ b/commands/undo.js
@@ -14,6 +14,11 @@ module.exports = {
 
     if (commands === null) {
       undos[message.guild.id].push({ thing: thing, command: undoCommand })
+      const debugUndo = `  DEBUG: 3. undo.js, undo created: ${JSON.stringify(undos[message.guild.id][undos[message.guild.id].length - 1])}`
+      console.log(debugUndo)
+      debugLog += debugUndo
+      // if debugFlag, DM debug
+      if (debugFlag) message.author.send([debugLog])
     } else {
       if (message.member.hasPermission('ADMINISTRATOR')) {
         if (undos[message.guild.id].length) {

--- a/commands/undo.js
+++ b/commands/undo.js
@@ -43,15 +43,15 @@ module.exports = {
               break
             case 'rename':
               // console.log(`  DEBUG: undo.js: reached rename case for ${undo.thing.name}`)
-              commands.get('adminRename').execute(message, undo.thing.name, undo.thing.value, debugLog, debugFlag, true, false, pointsName)
+              commands.get('rename').execute(message, undo.thing.name, undo.thing.value, debugLog, debugFlag, true, false, pointsName)
               break
             case 'set':
               // console.log(`  DEBUG: undo.js: reached set case for ${undo.thing.name}`)
-              commands.get('adminSet').execute(message, undo.thing.name, undo.thing.value, debugLog, debugFlag, true, false, pointsName)
+              commands.get('set').execute(message, undo.thing.name, undo.thing.value, debugLog, debugFlag, true, false, pointsName)
               break
             case 'untroll':
-              commands.get('adminSet').execute(message, undo.thing.thingName, undo.thing.thingKarma, debugLog, debugFlag, true, false, pointsName)
-              commands.get('adminSet').execute(message, undo.thing.userName, undo.thing.userKarma, debugLog, debugFlag, true, false, pointsName)
+              commands.get('set').execute(message, undo.thing.thingName, undo.thing.thingKarma, debugLog, debugFlag, true, false, pointsName)
+              commands.get('set').execute(message, undo.thing.userName, undo.thing.userKarma, debugLog, debugFlag, true, false, pointsName)
               break
             default:
               console.log('  DEBUG: undo.js: reached default case')


### PR DESCRIPTION
# Fix: Undo creation debug info

- Debug info will be sent for undo object upon creation. The following commands are affected:
  - newThing
  - adminDelete
  - trollDelete
  - incrementKarma
  - decrementKarma
  - set
  - rename
  - undo, of course