### PR TITLE
Change: move prefix to env var for testing bot, remove testing status

### DIFF
--- a/app.js
+++ b/app.js
@@ -33,7 +33,7 @@ let debugFlag = false
 // <prefix> <getThingName>
 
 // COMMAND PREFIX
-const prefix = 'sk '
+const prefix = process.env.PREFIX
 
 // MESSAGE HANDLER
 client.on('message', async message => {
@@ -236,9 +236,6 @@ client.on('ready', () => {
 
   // SET STATUS
   client.user.setActivity('"sk help"', { type: 'WATCHING' })
-
-  // Status for testing
-  // client.user.setActivity('"TESTING"', {})
 })
 
 // LOGIN


### PR DESCRIPTION
In order to separate testing from the deployment, I've created a new Discord app and bot identity to use for the local bot during testing. I will be using both versions of the bot on the same server. In order that they don't both respond to the same command, I've moved the prefix to env vars so they can each have their own. The testing status will no longer be needed in the code so that has been deleted.