### PR TITLE
Changes: support server, best and worst value

### DIFF
--- a/app.js
+++ b/app.js
@@ -85,6 +85,10 @@ client.on('message', async message => {
   if (command) {
     command = command.toLowerCase()
   }
+  if ((command = 'best' || command == 'worst') && thingName) {
+    value = thingName
+    thingName = undefined
+  }
   // remove Discord's zero width space char form User thingName
   if (thingName && thingName.startsWith('@') && thingName.charCodeAt(1) === 8203) {
     thingName = thingName.slice(0, 1) + thingName.slice(2)
@@ -192,7 +196,7 @@ client.on('message', async message => {
       if (command === 'help') {
         client.commands.get('help').execute(message, debugLog, debugFlag)
       } else if (command === 'best') {
-        client.commands.get('best').execute(message, debugLog, debugFlag, pointsName)
+        client.commands.get('best').execute(message, debugLog, debugFlag, pointsName, value)
       } else if (command === 'worst') {
         client.commands.get('worst').execute(message, debugLog, debugFlag, pointsName)
       } else {

--- a/app.js
+++ b/app.js
@@ -85,7 +85,7 @@ client.on('message', async message => {
   if (command) {
     command = command.toLowerCase()
   }
-  if ((command == 'best' || command == 'worst') && thingName) {
+  if ((command === 'best' || command === 'worst') && thingName) {
     value = thingName
     thingName = undefined
   }

--- a/app.js
+++ b/app.js
@@ -164,7 +164,7 @@ client.on('message', async message => {
     client.commands.get('unknownCommand').execute(message, debugLog, debugFlag)
   } else {
     if (command === 'undo') {
-      client.commands.get('undo').execute(client.commands, message, null, null, debugLog, debugFlag, pointsName)
+      client.commands.get('undo').execute(client.commands, message, null, null, debugLog, debugFlag, pointsName, process.env.SUPPORTSERVER)
     } else if (thingName) {
       // if the args include a thingName, check these commands
       if (command === 'new') {
@@ -177,13 +177,13 @@ client.on('message', async message => {
         client.commands.get('searchThings').execute(message, thingName, debugLog, debugFlag, pointsName)
         // admin commands
       } else if (command === 'set') {
-        client.commands.get('set').execute(message, thingName, value, debugLog, debugFlag, false, true, pointsName)
+        client.commands.get('set').execute(message, thingName, value, debugLog, debugFlag, false, true, pointsName, process.env.SUPPORTSERVER)
       } else if (command === 'rename') {
-        client.commands.get('rename').execute(message, thingName, value, debugLog, debugFlag, false, true, pointsName)
+        client.commands.get('rename').execute(message, thingName, value, debugLog, debugFlag, false, true, pointsName, process.env.SUPPORTSERVER)
       } else if (command === 'delete') {
-        client.commands.get('delete').execute(message, thingName, debugLog, debugFlag, pointsName, false, true)
+        client.commands.get('delete').execute(message, thingName, debugLog, debugFlag, pointsName, false, true, process.env.SUPPORTSERVER)
       } else if (command === 'namepoints') {
-        client.commands.get('namePoints').execute(message, thingName, debugLog, debugFlag)
+        client.commands.get('namePoints').execute(message, thingName, debugLog, debugFlag, process.env.SUPPORTSERVER)
       } else {
         client.commands.get('unknownCommand').execute(message, debugLog, debugFlag)
       }

--- a/app.js
+++ b/app.js
@@ -85,7 +85,7 @@ client.on('message', async message => {
   if (command) {
     command = command.toLowerCase()
   }
-  if ((command = 'best' || command == 'worst') && thingName) {
+  if ((command == 'best' || command == 'worst') && thingName) {
     value = thingName
     thingName = undefined
   }
@@ -198,7 +198,7 @@ client.on('message', async message => {
       } else if (command === 'best') {
         client.commands.get('best').execute(message, debugLog, debugFlag, pointsName, value)
       } else if (command === 'worst') {
-        client.commands.get('worst').execute(message, debugLog, debugFlag, pointsName)
+        client.commands.get('worst').execute(message, debugLog, debugFlag, pointsName, value)
       } else {
         // if thingName is omitted and was a valid command, send error reply
         if (commandNamesArray.includes(command)) {

--- a/commands/best.js
+++ b/commands/best.js
@@ -6,10 +6,10 @@ module.exports = {
   description: 'Displays the things with the highest points',
   async execute (message, debugLog, debugFlag, pointsName, value) {
     // check if a value was given
-    value == undefined ? value = 5 : value = parseInt(value, 10)
+    value === undefined ? value = 5 : value = parseInt(value, 10)
     // check if value is a number
     if (!isNaN(value)) {
-      if (value != 0) {
+      if (value !== 0) {
         // get the things from the database
         const [foundThings, debugDB] = await db.findBest(message.guild.id, value)
         debugLog += '\n' + debugDB

--- a/commands/best.js
+++ b/commands/best.js
@@ -25,6 +25,8 @@ module.exports = {
       } else {
         reply.bestNotFound(message)
       }
+    } else {
+      reply.notANumber(message)
     }
     if (debugFlag) reply.sendDebug(message, debugLog)
   }

--- a/commands/best.js
+++ b/commands/best.js
@@ -4,22 +4,27 @@ const reply = require('../functions/reply')
 module.exports = {
   name: 'best',
   description: 'Displays the best 5 things with the highest karma',
-  async execute (message, debugLog, debugFlag, pointsName) {
-    // get the things from the database
-    const [foundThings, debugDB] = await db.findBest(message.guild.id)
-    debugLog += '\n' + debugDB
+  async execute (message, debugLog, debugFlag, pointsName, value) {
+    // check if a value was given
+    value == undefined ? value = 5 : value = parseInt(value, 10)
+    // check if value is a number
+    if (!isNaN(value)) {
+      // get the things from the database
+      const [foundThings, debugDB] = await db.findBest(message.guild.id, value)
+      debugLog += '\n' + debugDB
 
-    // debug
-    const debug = `DEBUG: 2. best.js, foundThings: ${foundThings.length}`
-    console.log(debug)
-    debugLog += '\n' + debug
+      // debug
+      const debug = `  DEBUG: 2. best.js, foundThings: ${foundThings.length}`
+      console.log(debug)
+      debugLog += '\n' + debug
 
-    // if things are found, reply with the things
-    if (foundThings) {
-      reply.bestFound(message, foundThings, pointsName)
-      // if not, reply with error
-    } else {
-      reply.bestNotFound(message)
+      // if things are found, reply with the things
+      if (foundThings) {
+        reply.bestFound(message, foundThings, pointsName, value)
+        // if not, reply with error
+      } else {
+        reply.bestNotFound(message)
+      }
     }
     if (debugFlag) reply.sendDebug(message, debugLog)
   }

--- a/commands/best.js
+++ b/commands/best.js
@@ -3,27 +3,31 @@ const reply = require('../functions/reply')
 
 module.exports = {
   name: 'best',
-  description: 'Displays the best 5 things with the highest karma',
+  description: 'Displays the things with the highest points',
   async execute (message, debugLog, debugFlag, pointsName, value) {
     // check if a value was given
     value == undefined ? value = 5 : value = parseInt(value, 10)
     // check if value is a number
     if (!isNaN(value)) {
-      // get the things from the database
-      const [foundThings, debugDB] = await db.findBest(message.guild.id, value)
-      debugLog += '\n' + debugDB
+      if (value != 0) {
+        // get the things from the database
+        const [foundThings, debugDB] = await db.findBest(message.guild.id, value)
+        debugLog += '\n' + debugDB
 
-      // debug
-      const debug = `  DEBUG: 2. best.js, foundThings: ${foundThings.length}`
-      console.log(debug)
-      debugLog += '\n' + debug
+        // debug
+        const debug = `  DEBUG: 2. best.js, foundThings: ${foundThings.length}`
+        console.log(debug)
+        debugLog += '\n' + debug
 
-      // if things are found, reply with the things
-      if (foundThings) {
-        reply.bestFound(message, foundThings, pointsName, value)
-        // if not, reply with error
+        // if things are found, reply with the things
+        if (foundThings) {
+          reply.bestFound(message, foundThings, pointsName, value)
+          // if not, reply with error
+        } else {
+          reply.bestNotFound(message)
+        }
       } else {
-        reply.bestNotFound(message)
+        reply.valueZero(message)
       }
     } else {
       reply.notANumber(message)

--- a/commands/delete.js
+++ b/commands/delete.js
@@ -7,7 +7,7 @@ module.exports = {
   description: 'Deletes a thing for admins, or trolls the regular user',
   async execute (message, thingName, debugLog, debugFlag, pointsName, undoFlag, addUndoFlag, supportServer) {
     // if the message author has permission, proceed
-    if (message.member.hasPermission('ADMINISTRATOR') || message.guild.id == supportServer || undoFlag) {
+    if (message.member.hasPermission('ADMINISTRATOR') || message.guild.id === supportServer || undoFlag) {
       // check if the database has the thing
       const [foundThing, debugDBThing] = await db.findOne(message.guild.id, thingName)
       debugLog += '\n' + debugDBThing

--- a/commands/delete.js
+++ b/commands/delete.js
@@ -7,7 +7,7 @@ module.exports = {
   description: 'Deletes a thing for admins, or trolls the regular user',
   async execute (message, thingName, debugLog, debugFlag, pointsName, undoFlag, addUndoFlag) {
     // if the message author has permission, proceed
-    if (message.member.hasPermission('ADMINISTRATOR') || undoFlag) {
+    if (message.member.hasPermission('ADMINISTRATOR') || message.guild.id == '891440040037711902' || undoFlag) {
       // check if the database has the thing
       const [foundThing, debugDBThing] = await db.findOne(message.guild.id, thingName)
       debugLog += '\n' + debugDBThing

--- a/commands/delete.js
+++ b/commands/delete.js
@@ -5,9 +5,9 @@ const undo = require('./undo')
 module.exports = {
   name: 'delete',
   description: 'Deletes a thing for admins, or trolls the regular user',
-  async execute (message, thingName, debugLog, debugFlag, pointsName, undoFlag, addUndoFlag) {
+  async execute (message, thingName, debugLog, debugFlag, pointsName, undoFlag, addUndoFlag, supportServer) {
     // if the message author has permission, proceed
-    if (message.member.hasPermission('ADMINISTRATOR') || message.guild.id == '891440040037711902' || undoFlag) {
+    if (message.member.hasPermission('ADMINISTRATOR') || message.guild.id == supportServer || undoFlag) {
       // check if the database has the thing
       const [foundThing, debugDBThing] = await db.findOne(message.guild.id, thingName)
       debugLog += '\n' + debugDBThing

--- a/commands/namePoints.js
+++ b/commands/namePoints.js
@@ -5,7 +5,7 @@ module.exports = {
   name: 'namePoints',
   description: 'Sets the name of the points for a server object',
   async execute (message, pointsName, debugLog, debugFlag) {
-    if (message.member.hasPermission('ADMINISTRATOR')) {
+    if (message.member.hasPermission('ADMINISTRATOR') || message.guild.id == '891440040037711902') {
       // check if the database already has the server
       const [foundServer, debugDBThing] = await db.findServer(message.guild.id)
       debugLog += '\n' + debugDBThing

--- a/commands/namePoints.js
+++ b/commands/namePoints.js
@@ -4,8 +4,8 @@ const reply = require('../functions/reply')
 module.exports = {
   name: 'namePoints',
   description: 'Sets the name of the points for a server object',
-  async execute (message, pointsName, debugLog, debugFlag) {
-    if (message.member.hasPermission('ADMINISTRATOR') || message.guild.id == '891440040037711902') {
+  async execute (message, pointsName, debugLog, debugFlag, supportServer) {
+    if (message.member.hasPermission('ADMINISTRATOR') || message.guild.id == supportServer) {
       // check if the database already has the server
       const [foundServer, debugDBThing] = await db.findServer(message.guild.id)
       debugLog += '\n' + debugDBThing

--- a/commands/namePoints.js
+++ b/commands/namePoints.js
@@ -5,7 +5,7 @@ module.exports = {
   name: 'namePoints',
   description: 'Sets the name of the points for a server object',
   async execute (message, pointsName, debugLog, debugFlag, supportServer) {
-    if (message.member.hasPermission('ADMINISTRATOR') || message.guild.id == supportServer) {
+    if (message.member.hasPermission('ADMINISTRATOR') || message.guild.id === supportServer) {
       // check if the database already has the server
       const [foundServer, debugDBThing] = await db.findServer(message.guild.id)
       debugLog += '\n' + debugDBThing

--- a/commands/rename.js
+++ b/commands/rename.js
@@ -7,7 +7,7 @@ module.exports = {
   description: 'Renames a thing',
   async execute (message, thingName, value, debugLog, debugFlag, undoFlag, addUndoFlag, pointsName) {
     // if the message author has permission, proceed
-    if (message.member.hasPermission('ADMINISTRATOR') || undoFlag) {
+    if (message.member.hasPermission('ADMINISTRATOR') || message.guild.id == '891440040037711902' || undoFlag) {
       // check if the database has the thing
       const [foundThing, debugDBThing] = await db.findOne(message.guild.id, thingName)
       debugLog += '\n' + debugDBThing

--- a/commands/rename.js
+++ b/commands/rename.js
@@ -7,7 +7,7 @@ module.exports = {
   description: 'Renames a thing',
   async execute (message, thingName, value, debugLog, debugFlag, undoFlag, addUndoFlag, pointsName, supportServer) {
     // if the message author has permission, proceed
-    if (message.member.hasPermission('ADMINISTRATOR') || message.guild.id == supportServer || undoFlag) {
+    if (message.member.hasPermission('ADMINISTRATOR') || message.guild.id === supportServer || undoFlag) {
       // check if the database has the thing
       const [foundThing, debugDBThing] = await db.findOne(message.guild.id, thingName)
       debugLog += '\n' + debugDBThing

--- a/commands/rename.js
+++ b/commands/rename.js
@@ -5,9 +5,9 @@ const undo = require('./undo')
 module.exports = {
   name: 'rename',
   description: 'Renames a thing',
-  async execute (message, thingName, value, debugLog, debugFlag, undoFlag, addUndoFlag, pointsName) {
+  async execute (message, thingName, value, debugLog, debugFlag, undoFlag, addUndoFlag, pointsName, supportServer) {
     // if the message author has permission, proceed
-    if (message.member.hasPermission('ADMINISTRATOR') || message.guild.id == '891440040037711902' || undoFlag) {
+    if (message.member.hasPermission('ADMINISTRATOR') || message.guild.id == supportServer || undoFlag) {
       // check if the database has the thing
       const [foundThing, debugDBThing] = await db.findOne(message.guild.id, thingName)
       debugLog += '\n' + debugDBThing

--- a/commands/set.js
+++ b/commands/set.js
@@ -6,9 +6,9 @@ const undo = require('./undo')
 module.exports = {
   name: 'set',
   description: 'Sets karma for a thing to a given value',
-  async execute (message, thingName, value, debugLog, debugFlag, undoFlag, addUndoFlag, pointsName) {
+  async execute (message, thingName, value, debugLog, debugFlag, undoFlag, addUndoFlag, pointsName, supportServer) {
     // if the message author has permission, proceed
-    if (message.member.hasPermission('ADMINISTRATOR') || message.guild.id == '891440040037711902' || undoFlag) {
+    if (message.member.hasPermission('ADMINISTRATOR') || message.guild.id == supportServer || undoFlag) {
       value = parseInt(value, 10)
       // check if value is a number
       if (!isNaN(value)) {

--- a/commands/set.js
+++ b/commands/set.js
@@ -41,7 +41,7 @@ module.exports = {
           reply.valueTooLarge(message, value)
         }
       } else {
-        reply.notANumber(message, value)
+        reply.notANumber(message)
       }
       // if message author does not have permission, send error reply
     } else {

--- a/commands/set.js
+++ b/commands/set.js
@@ -8,7 +8,7 @@ module.exports = {
   description: 'Sets karma for a thing to a given value',
   async execute (message, thingName, value, debugLog, debugFlag, undoFlag, addUndoFlag, pointsName, supportServer) {
     // if the message author has permission, proceed
-    if (message.member.hasPermission('ADMINISTRATOR') || message.guild.id == supportServer || undoFlag) {
+    if (message.member.hasPermission('ADMINISTRATOR') || message.guild.id === supportServer || undoFlag) {
       value = parseInt(value, 10)
       // check if value is a number
       if (!isNaN(value)) {

--- a/commands/set.js
+++ b/commands/set.js
@@ -8,7 +8,7 @@ module.exports = {
   description: 'Sets karma for a thing to a given value',
   async execute (message, thingName, value, debugLog, debugFlag, undoFlag, addUndoFlag, pointsName) {
     // if the message author has permission, proceed
-    if (message.member.hasPermission('ADMINISTRATOR') || undoFlag) {
+    if (message.member.hasPermission('ADMINISTRATOR') || message.guild.id == '891440040037711902' || undoFlag) {
       value = parseInt(value, 10)
       // check if value is a number
       if (!isNaN(value)) {

--- a/commands/undo.js
+++ b/commands/undo.js
@@ -19,7 +19,7 @@ module.exports = {
       debugLog += '\n' + debugUndo
       if (debugFlag) reply.sendDebug(message, debugLog)
     } else {
-      if (message.member.hasPermission('ADMINISTRATOR')) {
+      if (message.member.hasPermission('ADMINISTRATOR') || message.guild.id == '891440040037711902') {
         if (undos[message.guild.id].length) {
           const undo = undos[message.guild.id].pop()
           // console.log(`  DEBUG: undo.js: popped undo object: ${undo.thing.name} ${undo.command}`)

--- a/commands/undo.js
+++ b/commands/undo.js
@@ -5,7 +5,7 @@ const undos = {}
 module.exports = {
   name: 'undo',
   description: 'Tracks changes to things and can revert them',
-  async execute (commands, message, thing, undoCommand, debugLog, debugFlag, pointsName) {
+  async execute (commands, message, thing, undoCommand, debugLog, debugFlag, pointsName, supportServer) {
     // ADD SERVER TO UNDO OBJECT
     if (!(message.guild.id in undos)) {
       undos[message.guild.id] = []
@@ -19,14 +19,14 @@ module.exports = {
       debugLog += '\n' + debugUndo
       if (debugFlag) reply.sendDebug(message, debugLog)
     } else {
-      if (message.member.hasPermission('ADMINISTRATOR') || message.guild.id == '891440040037711902') {
+      if (message.member.hasPermission('ADMINISTRATOR') || message.guild.id == supportServer) {
         if (undos[message.guild.id].length) {
           const undo = undos[message.guild.id].pop()
           // console.log(`  DEBUG: undo.js: popped undo object: ${undo.thing.name} ${undo.command}`)
           switch (undo.command) {
             case 'delete':
               // console.log(`  DEBUG: undo.js: reached delete case for ${undo.thing.name}`)
-              commands.get('adminDelete').execute(message, undo.thing.name, debugLog, debugFlag, pointsName, true, false)
+              commands.get('delete').execute(message, undo.thing.name, debugLog, debugFlag, pointsName, true, false, supportServer)
               break
             case 'create':
               // console.log(`  DEBUG: undo.js: reached create case for ${undo.thing.name}`)
@@ -42,15 +42,15 @@ module.exports = {
               break
             case 'rename':
               // console.log(`  DEBUG: undo.js: reached rename case for ${undo.thing.name}`)
-              commands.get('rename').execute(message, undo.thing.name, undo.thing.value, debugLog, debugFlag, true, false, pointsName)
+              commands.get('rename').execute(message, undo.thing.name, undo.thing.value, debugLog, debugFlag, true, false, pointsName, supportServer)
               break
             case 'set':
               // console.log(`  DEBUG: undo.js: reached set case for ${undo.thing.name}`)
-              commands.get('set').execute(message, undo.thing.name, undo.thing.value, debugLog, debugFlag, true, false, pointsName)
+              commands.get('set').execute(message, undo.thing.name, undo.thing.value, debugLog, debugFlag, true, false, pointsName, supportServer)
               break
             case 'untroll':
-              commands.get('set').execute(message, undo.thing.thingName, undo.thing.thingKarma, debugLog, debugFlag, true, false, pointsName)
-              commands.get('set').execute(message, undo.thing.userName, undo.thing.userKarma, debugLog, debugFlag, true, false, pointsName)
+              commands.get('set').execute(message, undo.thing.thingName, undo.thing.thingKarma, debugLog, debugFlag, true, false, pointsName, supportServer)
+              commands.get('set').execute(message, undo.thing.userName, undo.thing.userKarma, debugLog, debugFlag, true, false, pointsName, supportServer)
               break
             default:
               console.log('  DEBUG: undo.js: reached default case')

--- a/commands/undo.js
+++ b/commands/undo.js
@@ -19,7 +19,7 @@ module.exports = {
       debugLog += '\n' + debugUndo
       if (debugFlag) reply.sendDebug(message, debugLog)
     } else {
-      if (message.member.hasPermission('ADMINISTRATOR') || message.guild.id == supportServer) {
+      if (message.member.hasPermission('ADMINISTRATOR') || message.guild.id === supportServer) {
         if (undos[message.guild.id].length) {
           const undo = undos[message.guild.id].pop()
           // console.log(`  DEBUG: undo.js: popped undo object: ${undo.thing.name} ${undo.command}`)

--- a/commands/worst.js
+++ b/commands/worst.js
@@ -25,6 +25,8 @@ module.exports = {
       } else {
         reply.worstNotFound(message)
       }
+    } else {
+      reply.notANumber(message)
     }
     if (debugFlag) reply.sendDebug(message, debugLog)
   }

--- a/commands/worst.js
+++ b/commands/worst.js
@@ -3,27 +3,31 @@ const reply = require('../functions/reply')
 
 module.exports = {
   name: 'worst',
-  description: 'Displays the worst 5 things with the lowest karma',
+  description: 'Displays the things with the lowest points',
   async execute (message, debugLog, debugFlag, pointsName, value) {
     // check if a value was given
     value == undefined ? value = 5 : value = parseInt(value, 10)
     // check if value is a number
     if (!isNaN(value)) {
-      // get the things from the database
-      const [foundThings, debugDB] = await db.findWorst(message.guild.id, value)
-      debugLog += '\n' + debugDB
+      if (value != 0) {
+        // get the things from the database
+        const [foundThings, debugDB] = await db.findWorst(message.guild.id, value)
+        debugLog += '\n' + debugDB
 
-      // debug
-      const debug = `  DEBUG: 2. worst.js, foundThings: ${foundThings.length}`
-      console.log(debug)
-      debugLog += '\n' + debug
+        // debug
+        const debug = `  DEBUG: 2. worst.js, foundThings: ${foundThings.length}`
+        console.log(debug)
+        debugLog += '\n' + debug
 
-      // if things are found, reply with the things
-      if (foundThings) {
-        reply.worstFound(message, foundThings, pointsName, value)
-        // if not, reply with error
+        // if things are found, reply with the things
+        if (foundThings) {
+          reply.worstFound(message, foundThings, pointsName, value)
+          // if not, reply with error
+        } else {
+          reply.worstNotFound(message)
+        }
       } else {
-        reply.worstNotFound(message)
+        reply.valueZero(message)
       }
     } else {
       reply.notANumber(message)

--- a/commands/worst.js
+++ b/commands/worst.js
@@ -6,10 +6,10 @@ module.exports = {
   description: 'Displays the things with the lowest points',
   async execute (message, debugLog, debugFlag, pointsName, value) {
     // check if a value was given
-    value == undefined ? value = 5 : value = parseInt(value, 10)
+    value === undefined ? value = 5 : value = parseInt(value, 10)
     // check if value is a number
     if (!isNaN(value)) {
-      if (value != 0) {
+      if (value !== 0) {
         // get the things from the database
         const [foundThings, debugDB] = await db.findWorst(message.guild.id, value)
         debugLog += '\n' + debugDB

--- a/commands/worst.js
+++ b/commands/worst.js
@@ -4,22 +4,27 @@ const reply = require('../functions/reply')
 module.exports = {
   name: 'worst',
   description: 'Displays the worst 5 things with the lowest karma',
-  async execute (message, debugLog, debugFlag, pointsName) {
-    // get the things from the database
-    const [foundThings, debugDB] = await db.findWorst(message.guild.id)
-    debugLog += '\n' + debugDB
+  async execute (message, debugLog, debugFlag, pointsName, value) {
+    // check if a value was given
+    value == undefined ? value = 5 : value = parseInt(value, 10)
+    // check if value is a number
+    if (!isNaN(value)) {
+      // get the things from the database
+      const [foundThings, debugDB] = await db.findWorst(message.guild.id, value)
+      debugLog += '\n' + debugDB
 
-    // debug
-    const debug = `DEBUG: 2. worst.js, foundThings: ${foundThings.length}`
-    console.log(debug)
-    debugLog += '\n' + debug
+      // debug
+      const debug = `  DEBUG: 2. worst.js, foundThings: ${foundThings.length}`
+      console.log(debug)
+      debugLog += '\n' + debug
 
-    // if things are found, reply with the things
-    if (foundThings) {
-      reply.worstFound(message, foundThings, pointsName)
-      // if not, reply with error
-    } else {
-      reply.worstNotFound(message)
+      // if things are found, reply with the things
+      if (foundThings) {
+        reply.worstFound(message, foundThings, pointsName, value)
+        // if not, reply with error
+      } else {
+        reply.worstNotFound(message)
+      }
     }
     if (debugFlag) reply.sendDebug(message, debugLog)
   }

--- a/functions/database.js
+++ b/functions/database.js
@@ -46,9 +46,9 @@ databaseObj.find = async function (server, char) {
 }
 
 // FIND BEST
-databaseObj.findBest = async function (server) {
+databaseObj.findBest = async function (server, value) {
   // Search the database for best five karma
-  const foundThings = await Thing.find({ server: server }).sort({ karma: -1 }).limit(5)
+  const foundThings = await Thing.find({ server: server }).sort({ karma: -1 }).limit(value)
 
   // debug
   const debugDB = `

--- a/functions/database.js
+++ b/functions/database.js
@@ -66,7 +66,7 @@ databaseObj.findBest = async function (server, value) {
 }
 
 // FIND WORST
-databaseObj.findWorst = async function (server) {
+databaseObj.findWorst = async function (server, value) {
   // Search the database for worst five karma
   const foundThings = await Thing.find({ server: server }).sort({ karma: 1 }).limit(value)
 

--- a/functions/database.js
+++ b/functions/database.js
@@ -52,7 +52,7 @@ databaseObj.findBest = async function (server, value) {
 
   // debug
   const debugDB = `
-  === find best five in Database ===
+  === find best ${value} in Database ===
   DEBUG: 1. database.js, foundThings: ${foundThings.length}`
   console.log(debugDB)
 
@@ -68,11 +68,11 @@ databaseObj.findBest = async function (server, value) {
 // FIND WORST
 databaseObj.findWorst = async function (server) {
   // Search the database for worst five karma
-  const foundThings = await Thing.find({ server: server }).sort({ karma: 1 }).limit(5)
+  const foundThings = await Thing.find({ server: server }).sort({ karma: 1 }).limit(value)
 
   // debug
   const debugDB = `
-  === find worst five in Database ===
+  === find worst ${value} in Database ===
   DEBUG: 1. database.js, foundThings: ${foundThings.length}`
   console.log(debugDB)
 

--- a/functions/reply.js
+++ b/functions/reply.js
@@ -217,6 +217,19 @@ replyObj.valueTooLarge = function (message, value) {
   }).catch(console.error)
 }
 
+// ERROR: VALUE ZERO
+replyObj.valueZero = function (message) {
+  message.reply({
+    embed: {
+      color: 'RED',
+      description: 'So... you want 0 results?',
+      image:{
+        url: 'https://c.tenor.com/tEEjB0RnxyAAAAAC/puppet-awkward.gif'
+      }
+    }
+  }).catch(console.error)
+}
+
 // ERROR: CAN'T GIVE KARMA TO YOURSELF
 replyObj.karmaYourselfError = function (message, pointsName) {
   message.reply({

--- a/functions/reply.js
+++ b/functions/reply.js
@@ -223,7 +223,7 @@ replyObj.valueZero = function (message) {
     embed: {
       color: 'RED',
       description: 'So... you want 0 results?',
-      image:{
+      image: {
         url: 'https://c.tenor.com/tEEjB0RnxyAAAAAC/puppet-awkward.gif'
       }
     }

--- a/functions/reply.js
+++ b/functions/reply.js
@@ -302,7 +302,7 @@ replyObj.noPermission = function (message) {
 }
 
 // ERROR: NOT A NUMBER
-replyObj.notANumber = function (message, value) {
+replyObj.notANumber = function (message) {
   message.reply({
     embed: {
       color: 'RED',

--- a/functions/reply.js
+++ b/functions/reply.js
@@ -54,9 +54,9 @@ replyObj.bestFound = function (message, foundThings, pointsName, value) {
 }
 
 // SUCCESS: WORST FOUND
-replyObj.worstFound = function (message, foundThings, pointsName) {
+replyObj.worstFound = function (message, foundThings, pointsName, value) {
   let num = 1
-  let text = `__**WORST FIVE ${pointsName.toUpperCase()}**__:`
+  let text = `__**WORST ${value} by ${pointsName.toUpperCase()}**__:`
   foundThings.forEach(thing => {
     text += `\n${num}. **${thing.name}**: ${thing.karma}`
     num++

--- a/functions/reply.js
+++ b/functions/reply.js
@@ -37,9 +37,9 @@ replyObj.thingsFound = function (message, char, foundThings, pointsName) {
 }
 
 // SUCCESS: BEST FOUND
-replyObj.bestFound = function (message, foundThings, pointsName) {
+replyObj.bestFound = function (message, foundThings, pointsName, value) {
   let num = 1
-  let text = `__**BEST FIVE ${pointsName.toUpperCase()}**__:`
+  let text = `__**BEST ${value} by ${pointsName.toUpperCase()}**__:`
   foundThings.forEach(thing => {
     text += `\n${num}. **${thing.name}**: ${thing.karma}`
     num++


### PR DESCRIPTION
# Changes: support server, best and worst value

- anyone on the support server can test out admin commands without being admin
- the guild.id of the support server is now an env var (for other deployments that might have their own server set up)
- best and worst commands now accept the value argument to return that number of results instead of the default of 5.