### PR TITLE
Feature Update 13 (Bot Admins!)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ SimpleKarma is a Discord bot used to award things points. You can call the point
 
 **Admin Commands**
 - Syntax: \<prefix\> \<command\> \<thing\>(optional)
+- **`sk hire <@user>`**: Sets the mentioned user as an admin for SK.
+- **`sk fire <@user>`**: Removes the mentioned user as an admin for SK.
 - **`sk set <thing> <value>`**: Sets a \<thing\>'s points to the \<value\>.
 - **`sk rename <thing> <value>`**: Renames a \<thing\> to the \<value\>.
 - **`sk admindelete <thing>`**: Deletes a \<thing\>.

--- a/app.js
+++ b/app.js
@@ -77,7 +77,7 @@ client.on('message', async message => {
   let thingName = argsArray[1]
   let getThingName = argsArray[0]
   let value = argsArray[2]
-  let mentionID = message.mentions.users.firstKey()
+  const mentionID = message.mentions.users.firstKey()
 
   // args transformations
   if (getThingName === 'search )') {
@@ -193,7 +193,7 @@ client.on('message', async message => {
         client.commands.get('namePoints').execute(message, thingName, debugLog, debugFlag, process.env.SUPPORTSERVER)
       } else if (command === 'hire') {
         client.commands.get('hire').execute(message, thingName, mentionID, debugLog, debugFlag, true, process.env.SUPPORTSERVER)
-      }else if (command === 'fire') {
+      } else if (command === 'fire') {
         client.commands.get('fire').execute(message, thingName, mentionID, debugLog, debugFlag, true, process.env.SUPPORTSERVER)
       } else {
         client.commands.get('unknownCommand').execute(message, debugLog, debugFlag)

--- a/app.js
+++ b/app.js
@@ -191,6 +191,8 @@ client.on('message', async message => {
         client.commands.get('namePoints').execute(message, thingName, debugLog, debugFlag, process.env.SUPPORTSERVER)
       } else if (command === 'hire') {
         client.commands.get('hire').execute(message, thingName, mentionID, debugLog, debugFlag, true, process.env.SUPPORTSERVER)
+      }else if (command === 'fire') {
+        client.commands.get('fire').execute(message, thingName, mentionID, debugLog, debugFlag, true, process.env.SUPPORTSERVER)
       } else {
         client.commands.get('unknownCommand').execute(message, debugLog, debugFlag)
       }

--- a/app.js
+++ b/app.js
@@ -75,6 +75,7 @@ client.on('message', async message => {
   let thingName = argsArray[1]
   let getThingName = argsArray[0]
   let value = argsArray[2]
+  let mentionID = message.mentions.users.firstKey()
 
   // args transformations
   if (getThingName === 'search )') {
@@ -188,6 +189,8 @@ client.on('message', async message => {
         client.commands.get('delete').execute(message, thingName, debugLog, debugFlag, pointsName, false, true, process.env.SUPPORTSERVER)
       } else if (command === 'namepoints') {
         client.commands.get('namePoints').execute(message, thingName, debugLog, debugFlag, process.env.SUPPORTSERVER)
+      } else if (command === 'hire') {
+        client.commands.get('hire').execute(message, thingName, mentionID, debugLog, debugFlag, true, process.env.SUPPORTSERVER)
       } else {
         client.commands.get('unknownCommand').execute(message, debugLog, debugFlag)
       }

--- a/app.js
+++ b/app.js
@@ -36,9 +36,11 @@ client.on('message', async message => {
   // FILTER OUT MESSAGES
   // if message is a DM, it won't have the correct object methods for some commands and could cause a crash
   // if message doesn't start with the prefix or is form a bot, ignore and return to break out
-  if (!message.guild || !message.content.toLowerCase().startsWith(prefix) || message.author.bot) {
+  if (!message.guild || !message.content.toLowerCase().startsWith(prefix) || (message.author.id === client.user.id)) {
     return
   }
+
+  console.log(message.author.id, client.user.id)
 
   // CREATE DEBUG LOG
   let debugLog = ''

--- a/commands/delete.js
+++ b/commands/delete.js
@@ -7,7 +7,9 @@ module.exports = {
   description: 'Deletes a thing for admins, or trolls the regular user',
   async execute (message, thingName, debugLog, debugFlag, pointsName, undoFlag, addUndoFlag, supportServer) {
     // if the message author has permission, proceed
-    if (message.member.hasPermission('ADMINISTRATOR') || message.guild.id === supportServer || undoFlag) {
+    const [isAdmin, debugIsAdmin] = await db.isAdmin(message.guild.id, message.member.id)
+    debugLog += '\n' + debugIsAdmin
+    if (message.member.hasPermission('ADMINISTRATOR') || message.guild.id === supportServer || undoFlag || isAdmin) {
       // check if the database has the thing
       const [foundThing, debugDBThing] = await db.findOne(message.guild.id, thingName)
       debugLog += '\n' + debugDBThing

--- a/commands/fire.js
+++ b/commands/fire.js
@@ -1,0 +1,47 @@
+// Require functions
+const db = require('../functions/database')
+const reply = require('../functions/reply')
+const undo = require('./undo')
+
+module.exports = {
+  name: 'fire',
+  description: 'Deletes an admin',
+  async execute (message, adminName, adminID, debugLog, debugFlag, addUndoFlag, supportServer) {
+    if (message.member.hasPermission('ADMINISTRATOR') || message.guild.id === supportServer) {
+      // check if the database has the admin
+      const [foundAdmin, debugDB] = await db.findAdmin(message.guild.id, adminID)
+
+      // debug
+      const debug = `  DEBUG: 2. fire.js, foundAdmin: ${foundAdmin ? foundAdmin.adminID : foundAdmin}`
+      console.log(debug)
+      debugLog += '\n' + debugDB + '\n' + debug
+
+      // if it does't, send reply to message's channel with error and instructions for how to hire the admin
+      if (!foundAdmin) {
+        reply.adminNotFound(message, adminName)
+      // if it does, fire the admin then send reply to the message's channel confirming it's termination
+      } else {
+        const [res, debugDBfire] = await db.fire(message.guild.id, foundAdmin.adminID)
+        debugLog += '\n' + debugDBfire
+
+        // debug
+        const debugFire = `  DEBUG: 2. fire.js, res: ${res}`
+        console.log(debugFire)
+        debugLog += '\n' + debugFire
+
+        if (res === 1) {
+          reply.adminFired(message, foundAdmin.adminName)
+          if (addUndoFlag) {
+            undo.execute(null, message, foundAdmin, 'hire', debugLog, debugFlag, null)
+            debugFlag = false
+          }
+        } else {
+          reply.adminNotFired(message, foundAdmin.adminName)
+        }
+      }
+      if (debugFlag) reply.sendDebug(message, debugLog)
+    } else {
+      reply.noPermission(message)
+    }
+  }
+}

--- a/commands/fire.js
+++ b/commands/fire.js
@@ -16,7 +16,7 @@ module.exports = {
       console.log(debug)
       debugLog += '\n' + debugDB + '\n' + debug
 
-      // if it does't, send reply to message's channel with error and instructions for how to hire the admin
+      // if it does't, send reply to message's channel with error
       if (!foundAdmin) {
         reply.adminNotFound(message, adminName)
       // if it does, fire the admin then send reply to the message's channel confirming it's termination

--- a/commands/fire.js
+++ b/commands/fire.js
@@ -30,7 +30,7 @@ module.exports = {
         debugLog += '\n' + debugFire
 
         if (res === 1) {
-          reply.adminFired(message, foundAdmin.adminName)
+          reply.adminFired(message, foundAdmin)
           if (addUndoFlag) {
             undo.execute(null, message, foundAdmin, 'hire', debugLog, debugFlag, null)
             debugFlag = false

--- a/commands/help.js
+++ b/commands/help.js
@@ -22,6 +22,8 @@ module.exports = {
 
     message.reply([
       '__**ADMIN Commands:**__ (Requires Server Admin Permissions)',
+      '**`sk hire <@user>`**: Sets the mentioned user as an admin for SK',
+      '**`sk fire <@user>`**: Removes the mentioned user as an admin for SK',
       '**`sk set <thing> <value>`**: Sets a thing\'s points to the value',
       '**`sk rename <thing> <value>`**: Renames a thing to the value',
       '**`sk delete <thing>`**: Deletes a thing',

--- a/commands/help.js
+++ b/commands/help.js
@@ -17,7 +17,7 @@ module.exports = {
       '*- Thing names in parentheses can have spaces.*',
       '*- User Thing names with spaces must have a space between the `@` and the rest of the name.*',
       '  *- Example: `(@ Joe User)` for `@Joe User`*',
-      '*- Add `debug` anywhere in any command to have debug info DM\'d to you.*',
+      '*- Add `debug` anywhere in any command to have debug info DM\'d to you.*'
     ])
 
     message.reply([

--- a/commands/hire.js
+++ b/commands/hire.js
@@ -1,0 +1,40 @@
+// Require functions
+const db = require('../functions/database')
+const reply = require('../functions/reply')
+const undo = require('./undo')
+
+module.exports = {
+  name: 'hire',
+  description: 'Creates a new admin',
+  async execute (message, adminName, adminID, debugLog, debugFlag, addUndoFlag, supportServer) {
+    if (message.member.hasPermission('ADMINISTRATOR') || message.guild.id === supportServer) {
+      // check if the database already has the admin
+      const [foundAdmin, debugDB] = await db.findAdmin(message.guild.id, adminID)
+
+      // debug
+      const debug = `  DEBUG: 2. hire.js, foundAdmin: ${foundAdmin ? foundAdmin.adminID : foundAdmin}`
+      console.log(debug)
+      debugLog += '\n' + debugDB + '\n' + debug
+
+      // if it does, send reply to the massage's channel explaining so
+      if (foundAdmin) {
+        reply.adminAlreadyHired(message, foundAdmin)
+      // if it doesn't, hire the admin then send reply to the message's channel confirming it's employment
+      } else {
+        const newAdmin = await db.hire(message.guild.id, adminName, adminID)
+        if (newAdmin) {
+          reply.AdminHired(message, newAdmin)
+          if (addUndoFlag) {
+            undo.execute(null, message, newAdmin, 'fire', debugLog, debugFlag, null)
+            debugFlag = false
+          }
+        } else {
+          reply.adminNotHired(message, adminName)
+        }
+      }
+      if (debugFlag) reply.sendDebug(message, debugLog)
+    } else {
+      reply.noPermission(message)
+    }
+  }
+}

--- a/commands/hire.js
+++ b/commands/hire.js
@@ -23,7 +23,7 @@ module.exports = {
       } else {
         const newAdmin = await db.hire(message.guild.id, adminName, adminID)
         if (newAdmin) {
-          reply.AdminHired(message, newAdmin)
+          reply.adminHired(message, newAdmin)
           if (addUndoFlag) {
             undo.execute(null, message, newAdmin, 'fire', debugLog, debugFlag, null)
             debugFlag = false

--- a/commands/hire.js
+++ b/commands/hire.js
@@ -21,7 +21,7 @@ module.exports = {
         reply.adminAlreadyHired(message, foundAdmin)
       // if it doesn't, hire the admin then send reply to the message's channel confirming it's employment
       } else {
-        const newAdmin = await db.hire(message.guild.id, adminName, adminID)
+        const newAdmin = await db.hire(message.guild.id, adminID, adminName)
         if (newAdmin) {
           reply.adminHired(message, newAdmin)
           if (addUndoFlag) {

--- a/commands/namePoints.js
+++ b/commands/namePoints.js
@@ -5,7 +5,9 @@ module.exports = {
   name: 'namePoints',
   description: 'Sets the name of the points for a server object',
   async execute (message, pointsName, debugLog, debugFlag, supportServer) {
-    if (message.member.hasPermission('ADMINISTRATOR') || message.guild.id === supportServer) {
+    const [isAdmin, debugIsAdmin] = await db.isAdmin(message.guild.id, message.member.id)
+    debugLog += '\n' + debugIsAdmin
+    if (message.member.hasPermission('ADMINISTRATOR') || message.guild.id === supportServer || isAdmin) {
       // check if the database already has the server
       const [foundServer, debugDBThing] = await db.findServer(message.guild.id)
       debugLog += '\n' + debugDBThing

--- a/commands/rename.js
+++ b/commands/rename.js
@@ -7,7 +7,9 @@ module.exports = {
   description: 'Renames a thing',
   async execute (message, thingName, value, debugLog, debugFlag, undoFlag, addUndoFlag, pointsName, supportServer) {
     // if the message author has permission, proceed
-    if (message.member.hasPermission('ADMINISTRATOR') || message.guild.id === supportServer || undoFlag) {
+    const [isAdmin, debugIsAdmin] = await db.isAdmin(message.guild.id, message.member.id)
+    debugLog += '\n' + debugIsAdmin
+    if (message.member.hasPermission('ADMINISTRATOR') || message.guild.id === supportServer || undoFlag || isAdmin) {
       // check if the database has the thing
       const [foundThing, debugDBThing] = await db.findOne(message.guild.id, thingName)
       debugLog += '\n' + debugDBThing

--- a/commands/set.js
+++ b/commands/set.js
@@ -8,7 +8,9 @@ module.exports = {
   description: 'Sets karma for a thing to a given value',
   async execute (message, thingName, value, debugLog, debugFlag, undoFlag, addUndoFlag, pointsName, supportServer) {
     // if the message author has permission, proceed
-    if (message.member.hasPermission('ADMINISTRATOR') || message.guild.id === supportServer || undoFlag) {
+    const [isAdmin, debugIsAdmin] = await db.isAdmin(message.guild.id, message.member.id)
+    debugLog += '\n' + debugIsAdmin
+    if (message.member.hasPermission('ADMINISTRATOR') || message.guild.id === supportServer || undoFlag || isAdmin) {
       value = parseInt(value, 10)
       // check if value is a number
       if (!isNaN(value)) {

--- a/commands/undo.js
+++ b/commands/undo.js
@@ -52,6 +52,12 @@ module.exports = {
               commands.get('set').execute(message, undo.thing.thingName, undo.thing.thingKarma, debugLog, debugFlag, true, false, pointsName, supportServer)
               commands.get('set').execute(message, undo.thing.userName, undo.thing.userKarma, debugLog, debugFlag, true, false, pointsName, supportServer)
               break
+            case 'hire':
+              commands.get('hire').execute(message, undo.thing.adminName, undo.thing.adminID, debugLog, debugFlag, false, supportServer)
+              break
+            case 'fire':
+              commands.get('fire').execute(message, undo.thing.adminName, undo.thing.adminID, debugLog, debugFlag, false, supportServer)
+              break
             default:
               console.log('  DEBUG: undo.js: reached default case')
               reply.noUndoCase(message)

--- a/commands/undo.js
+++ b/commands/undo.js
@@ -1,3 +1,4 @@
+const db = require('../functions/database')
 const reply = require('../functions/reply')
 // Undo Object, keys are guild.id, values are arrays of undo objects for the keys server
 const undos = {}
@@ -19,7 +20,9 @@ module.exports = {
       debugLog += '\n' + debugUndo
       if (debugFlag) reply.sendDebug(message, debugLog)
     } else {
-      if (message.member.hasPermission('ADMINISTRATOR') || message.guild.id === supportServer) {
+      const [isAdmin, debugIsAdmin] = await db.isAdmin(message.guild.id, message.member.id)
+      debugLog += '\n' + debugIsAdmin
+      if (message.member.hasPermission('ADMINISTRATOR') || message.guild.id === supportServer || isAdmin) {
         if (undos[message.guild.id].length) {
           const undo = undos[message.guild.id].pop()
           // console.log(`  DEBUG: undo.js: popped undo object: ${undo.thing.name} ${undo.command}`)

--- a/functions/database.js
+++ b/functions/database.js
@@ -108,7 +108,7 @@ databaseObj.findPointsName = async function (messageID) {
 // FIND ADMIN
 databaseObj.findAdmin = async function (server, adminID) {
   // check if the database has the admin
-  const foundThing = await Admin.findOne({ server: server, adminID: adminID }).exec()
+  const foundAdmin = await Admin.findOne({ server: server, adminID: adminID }).exec()
 
   // debug
   const debugDB = `

--- a/functions/database.js
+++ b/functions/database.js
@@ -200,7 +200,7 @@ databaseObj.hire = async function (serverID, adminID, adminName) {
 
 // FIRE ADMIN
 databaseObj.fire = async function (serverID, adminID) {
-  const res = await Thing.deleteOne({ serverID: serverID, adminID: adminID })
+  const res = await Admin.deleteOne({ serverID: serverID, adminID: adminID })
 
   // debug
   const debugDB = `

--- a/functions/database.js
+++ b/functions/database.js
@@ -1,5 +1,6 @@
 const Thing = require('../models/thing')
 const Server = require('../models/server')
+const Admin = require('../models/admin')
 
 const databaseObj = {}
 

--- a/functions/database.js
+++ b/functions/database.js
@@ -106,9 +106,9 @@ databaseObj.findPointsName = async function (messageID) {
 }
 
 // FIND ADMIN
-databaseObj.findAdmin = async function (server, adminID) {
+databaseObj.findAdmin = async function (serverID, adminID) {
   // check if the database has the admin
-  const foundAdmin = await Admin.findOne({ server: server, adminID: adminID }).exec()
+  const foundAdmin = await Admin.findOne({ serverID: serverID, adminID: adminID }).exec()
 
   // debug
   const debugDB = `

--- a/functions/database.js
+++ b/functions/database.js
@@ -198,5 +198,18 @@ databaseObj.hire = async function (serverID, adminID, adminName) {
   }
 }
 
+// FIRE ADMIN
+databaseObj.fire = async function (serverID, adminID) {
+  const res = await Thing.deleteOne({ serverID: serverID, adminID: adminID })
+
+  // debug
+  const debugDB = `
+  === fire from Database ===
+  DEBUG: 1. database.js, res: ${res.ok}`
+  console.log(debugDB)
+
+  return [res.ok, debugDB]
+}
+
 //  Export find object
 module.exports = databaseObj

--- a/functions/database.js
+++ b/functions/database.js
@@ -211,5 +211,26 @@ databaseObj.fire = async function (serverID, adminID) {
   return [res.ok, debugDB]
 }
 
+// IS ADMIN
+databaseObj.isAdmin = async function (serverID, adminID) {
+  // check if the database has the admin
+  const foundAdmin = await Admin.findOne({ serverID: serverID, adminID: adminID }).exec()
+
+  // debug
+  const debugDB = `
+  === isAdmin in Database ===
+  DEBUG: 1a. database.js, adminID: ${adminID}
+  DEBUG: 1b. database.js, foundAdmin: ${foundAdmin ? foundAdmin.adminName : foundAdmin}`
+  console.log(debugDB)
+
+  // if it does, return true
+  if (foundAdmin) {
+    return [true, debugDB]
+    // if it doesn't, return false
+  } else {
+    return [false, debugDB]
+  }
+}
+
 //  Export find object
 module.exports = databaseObj

--- a/functions/database.js
+++ b/functions/database.js
@@ -185,9 +185,9 @@ databaseObj.createServer = async function (id, pointsName) {
   }
 }
 
-// CREATE THING
+// HIRE ADMIN
 databaseObj.hire = async function (serverID, adminID, adminName) {
-  const newThing = await Admin.create({ serverID: serverID, adminID: adminID, adminName: adminName })
+  const newAdmin = await Admin.create({ serverID: serverID, adminID: adminID, adminName: adminName })
 
   // if it hire is successful, return the admin
   if (newAdmin) {

--- a/functions/database.js
+++ b/functions/database.js
@@ -185,5 +185,18 @@ databaseObj.createServer = async function (id, pointsName) {
   }
 }
 
+// CREATE THING
+databaseObj.hire = async function (serverID, adminID, adminName) {
+  const newThing = await Admin.create({ serverID: serverID, adminID: adminID, adminName: adminName })
+
+  // if it hire is successful, return the admin
+  if (newAdmin) {
+    return newAdmin
+    // if the hire fails, return null
+  } else {
+    return null
+  }
+}
+
 //  Export find object
 module.exports = databaseObj

--- a/functions/database.js
+++ b/functions/database.js
@@ -105,6 +105,27 @@ databaseObj.findPointsName = async function (messageID) {
   }
 }
 
+// FIND ADMIN
+databaseObj.findAdmin = async function (server, adminID) {
+  // check if the database has the admin
+  const foundThing = await Admin.findOne({ server: server, adminID: adminID }).exec()
+
+  // debug
+  const debugDB = `
+  === findAdmin in Database ===
+  DEBUG: 1a. database.js, adminID: ${adminID}
+  DEBUG: 1b. database.js, foundAdmin: ${foundAdmin ? foundAdmin.adminName : foundAdmin}`
+  console.log(debugDB)
+
+  // if it does, return the admin
+  if (foundAdmin) {
+    return [foundAdmin, debugDB]
+    // if it doesn't, return null
+  } else {
+    return [null, debugDB]
+  }
+}
+
 // CREATE THING
 databaseObj.create = async function (server, thingName, karma) {
   const newThing = await Thing.create({ server: server, name: thingName, nameLower: thingName.toLowerCase(), karma: karma })

--- a/functions/reply.js
+++ b/functions/reply.js
@@ -459,5 +459,15 @@ replyObj.adminNotHired = function (message, adminName) {
   }).catch(console.error)
 }
 
+// ERROR: ADMIN NOT FOUND
+replyObj.adminNotFound = function (message, adminName) {
+  message.reply({
+    embed: {
+      color: 'RED',
+      description: `**${adminName}** doesn't work here!`
+    }
+  }).catch(console.error)
+}
+
 //  Export reply object
 module.exports = replyObj

--- a/functions/reply.js
+++ b/functions/reply.js
@@ -439,6 +439,16 @@ replyObj.adminAlreadyHired = function (message, foundAdmin) {
   }).catch(console.error)
 }
 
+// SUCCESS: ADMIN HIRED
+replyObj.adminHired = function (message, newAdmin) {
+  message.reply({
+    embed: {
+      color: 'BLUE',
+      description: `New Admin, **${newAdmin.adminName}**, has been hired!`
+    }
+  }).catch(console.error)
+}
+
 
 //  Export reply object
 module.exports = replyObj

--- a/functions/reply.js
+++ b/functions/reply.js
@@ -474,7 +474,8 @@ replyObj.adminFired = function (message, adminName) {
   message.reply({
     embed: {
       color: 'BLUE',
-      description: `Admin, **${adminName}**, has been fired!`
+      description: `Admin, **@${adminName}**, has been fired!\n
+      https://tenor.com/view/fired-office-michael-scott-the-gif-22021313`
     }
   }).catch(console.error)
 }

--- a/functions/reply.js
+++ b/functions/reply.js
@@ -383,6 +383,13 @@ replyObj.nextUndo = function (message, undo) {
         description: 'Next undo will **' + undo.command + ' ' + undo.thing.thingName + '** and **' + undo.command + ' ' + undo.thing.userName + '**.'
       }
     }).catch(console.error)
+  } else if (undo.command === 'fire' || undo.command === 'hire') {
+    message.reply({
+      embed: {
+        color: 'GREY',
+        description: 'Next undo will **' + undo.command + ' ' + undo.thing.adminName + '**.'
+      }
+    }).catch(console.error)
   } else {
     message.reply({
       embed: {

--- a/functions/reply.js
+++ b/functions/reply.js
@@ -449,6 +449,15 @@ replyObj.adminHired = function (message, newAdmin) {
   }).catch(console.error)
 }
 
+// ERROR: ADMIN COULD NOT BE HIRED
+replyObj.adminNotHired = function (message, adminName) {
+  message.reply({
+    embed: {
+      color: 'RED',
+      description: 'A database **ERROR** ocurred and admin, **' + adminName + '**, was not hired :('
+    }
+  }).catch(console.error)
+}
 
 //  Export reply object
 module.exports = replyObj

--- a/functions/reply.js
+++ b/functions/reply.js
@@ -479,5 +479,15 @@ replyObj.adminFired = function (message, adminName) {
   }).catch(console.error)
 }
 
+// ERROR: ADMIN NOT FIRED
+replyObj.adminNotFired = function (message, adminName) {
+  message.reply({
+    embed: {
+      color: 'RED',
+      description: 'A database **ERROR** ocurred and admin, **' + adminName + '**, was not fired :('
+    }
+  }).catch(console.error)
+}
+
 //  Export reply object
 module.exports = replyObj

--- a/functions/reply.js
+++ b/functions/reply.js
@@ -441,6 +441,7 @@ replyObj.adminAlreadyHired = function (message, foundAdmin) {
 
 // SUCCESS: ADMIN HIRED
 replyObj.adminHired = function (message, newAdmin) {
+  message.channel.send(`<@${newAdmin.adminID}>`)
   message.reply({
     embed: {
       color: 'BLUE',
@@ -470,14 +471,14 @@ replyObj.adminNotFound = function (message, adminName) {
 }
 
 // SUCCESS: ADMIN FIRED
-replyObj.adminFired = function (message, adminName) {
+replyObj.adminFired = function (message, admin) {
   message.reply({
     embed: {
       color: 'BLUE',
-      description: `Admin, **@${adminName}**, has been fired!\n
-      https://tenor.com/view/fired-office-michael-scott-the-gif-22021313`
+      description: `Admin, **${admin.adminName}**, has been fired!`
     }
   }).catch(console.error)
+  message.channel.send(`<@${admin.adminID}>\nhttps://tenor.com/view/fired-office-michael-scott-the-gif-22021313`)
 }
 
 // ERROR: ADMIN NOT FIRED

--- a/functions/reply.js
+++ b/functions/reply.js
@@ -429,5 +429,16 @@ replyObj.sendDebug = function (message, debugLog) {
   }
 }
 
+// ERROR: ADMIN ALREADY HIRED
+replyObj.adminAlreadyHired = function (message, foundAdmin) {
+  message.reply({
+    embed: {
+      color: 'RED',
+      description: 'Admin, **' + foundAdmin.adminName + '**, already hired!'
+    }
+  }).catch(console.error)
+}
+
+
 //  Export reply object
 module.exports = replyObj

--- a/functions/reply.js
+++ b/functions/reply.js
@@ -469,5 +469,15 @@ replyObj.adminNotFound = function (message, adminName) {
   }).catch(console.error)
 }
 
+// SUCCESS: ADMIN FIRED
+replyObj.adminFired = function (message, adminName) {
+  message.reply({
+    embed: {
+      color: 'BLUE',
+      description: `Admin, **${adminName}**, has been fired!`
+    }
+  }).catch(console.error)
+}
+
 //  Export reply object
 module.exports = replyObj

--- a/models/admin.js
+++ b/models/admin.js
@@ -1,0 +1,9 @@
+const mongoose = require('mongoose')
+
+// ADMIN MONGOOSE MODEL
+const AdminSchema = new mongoose.Schema({
+  serverID: String,
+  memberID: String
+})
+
+module.exports = mongoose.model('Admin', AdminSchema)

--- a/models/admin.js
+++ b/models/admin.js
@@ -3,7 +3,8 @@ const mongoose = require('mongoose')
 // ADMIN MONGOOSE MODEL
 const AdminSchema = new mongoose.Schema({
   serverID: String,
-  memberID: String
+  adminID: String,
+  adminName: String
 })
 
 module.exports = mongoose.model('Admin', AdminSchema)

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "app.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "node app.js"
+    "start": "node app.js",
+    "kakashi": "(cd ../kakashi-bot && go run main.go) & npm start"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
# Feature Update 13 (Bot Admins!)

- 2 new commands, `sk hire <mention>` and `sk fire <mention>` allow you to make users admins just for SK without giving them server-wide permissions.
- For integration testing purposes, SK now supports the use of [KakashiBot](https://github.com/LouisSavoie/kakashi-bot) via a new NPM script, `npm run kakashi`, which will start both SK and KakashiBot locally.

**Changes:**
- add admin model
- add hire & fire commands
- add new database module functions
  - db.findAdmin
  - db.isAdmin
  - db.hire
  - db.fire
- addnew reply module functions
  - reply.adminAlreadyHired
  - reply.adminHired
  - reply.adminNotHired
  - reply.adminNotFound
  - reply.adminFired
  - reply.adminNotFired
- add hire & fire to undo command
- add hire & fire to command tree
- add isAdmin to permissions checks in all admin commands
- add "kakashi" npm script
- change ignore bots code to ignore self in message handler
- add hire & firer to README and help command