### PR TITLE
Fix: multi-whitespace breaking args parsing

### DIFF
--- a/app.js
+++ b/app.js
@@ -65,7 +65,7 @@ client.on('message', async message => {
   // COMMAND ARGS PROCESSING
   // remove the prefix from the message, convert mentions to plain strings,
   // split the arguments into an array by spaces, allow things with spaces between parens
-  const argsArray = message.cleanContent.slice(prefix.length).split(/(?!\(.*)\s(?![^(]*?\))/g)
+  const argsArray = message.cleanContent.slice(prefix.length).split(/(?!\(.*)\s+(?![^(]*?\))/g)
 
   if (argsArray.includes('debug')) {
     argsArray.splice(argsArray.indexOf('debug'), 1)


### PR DESCRIPTION
When a user would add extra whitespace between arguments in the command they were issuing it would throw odd errors depending on the command. This fixes that by adjusting the main regex the parsing uses to split the arguments so that it splits by one or more whitespace instead of just one.